### PR TITLE
fix: show GP name for upcoming races and make countdown tick live

### DIFF
--- a/src/theundercut/api/v1/race.py
+++ b/src/theundercut/api/v1/race.py
@@ -26,6 +26,26 @@ logger = logging.getLogger(__name__)
 
 OPENF1_MEETING_CACHE_TTL_SECONDS = 3600  # 1 hour
 
+# Map OpenF1 circuit_short_name to Jolpica-style circuit IDs used by the frontend.
+# Only entries where the names diverge need to be listed; circuits whose
+# short_name.lower().replace(" ", "_") already matches the Jolpica ID are
+# resolved automatically.
+OPENF1_TO_JOLPICA_CIRCUIT: dict[str, str] = {
+    "Melbourne": "albert_park",
+    "Sakhir": "bahrain",
+    "Monte Carlo": "monaco",
+    "Montreal": "villeneuve",
+    "Spielberg": "red_bull_ring",
+    "Spa-Francorchamps": "spa",
+    "Singapore": "marina_bay",
+    "Austin": "americas",
+    "Mexico City": "rodriguez",
+    "Las Vegas": "vegas",
+    "Lusail": "losail",
+    "Yas Marina Circuit": "yas_marina",
+    "Madrid": "madring",
+}
+
 SESSION_RESULTS_TO_FETCH: Tuple[str, ...] = (
     "fp1",
     "fp2",
@@ -622,7 +642,11 @@ def _get_circuit_info(season: int, rnd: int, db: Session) -> dict:
         meeting = _fetch_openf1_meeting(event.meeting_key)
         if meeting:
             circuit_short = meeting.get("circuit_short_name") or ""
-            circuit_id = circuit_short.lower().replace(" ", "_").replace("-", "_") if circuit_short else f"circuit_{season}_{rnd}"
+            # Use explicit mapping first, then fall back to normalised short name
+            circuit_id = OPENF1_TO_JOLPICA_CIRCUIT.get(
+                circuit_short,
+                circuit_short.lower().replace(" ", "_").replace("-", "_") if circuit_short else f"circuit_{season}_{rnd}",
+            )
             return {
                 "circuit_id": circuit_id,
                 "circuit_name": circuit_short or None,

--- a/src/theundercut/api/v1/race.py
+++ b/src/theundercut/api/v1/race.py
@@ -1,7 +1,10 @@
 # src/theundercut/api/v1/race.py
 import json
+import logging
 import datetime as dt
 from typing import Optional, Tuple, List
+
+import httpx
 
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.orm import Session
@@ -18,6 +21,10 @@ from theundercut.services.cache import (
     SESSION_CACHE_PREFIX,
 )
 from theundercut.services.standings import fetch_season_standings
+
+logger = logging.getLogger(__name__)
+
+OPENF1_MEETING_CACHE_TTL_SECONDS = 3600  # 1 hour
 
 SESSION_RESULTS_TO_FETCH: Tuple[str, ...] = (
     "fp1",
@@ -558,8 +565,35 @@ def _build_next_race_preview(weekend: Optional[WeekendResponse]) -> Optional[Nex
     )
 
 
+def _fetch_openf1_meeting(meeting_key: int) -> Optional[dict]:
+    """Fetch meeting metadata from OpenF1, with Redis caching."""
+    cache_key = f"openf1:meeting:{meeting_key}"
+    cached = redis_client.get(cache_key)
+    if cached:
+        try:
+            return json.loads(cached)
+        except Exception:
+            redis_client.delete(cache_key)
+
+    try:
+        with httpx.Client(timeout=10) as client:
+            resp = client.get(
+                "https://api.openf1.org/v1/meetings",
+                params={"meeting_key": meeting_key},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            if data and isinstance(data, list) and len(data) > 0:
+                meeting = data[0]
+                redis_client.setex(cache_key, OPENF1_MEETING_CACHE_TTL_SECONDS, json.dumps(meeting))
+                return meeting
+    except Exception as exc:
+        logger.warning("Failed to fetch OpenF1 meeting %s: %s", meeting_key, exc)
+    return None
+
+
 def _get_circuit_info(season: int, rnd: int, db: Session) -> dict:
-    """Get circuit info from Race and Circuit tables."""
+    """Get circuit info from Race and Circuit tables, falling back to OpenF1."""
     # Try to get from Race table with Circuit join
     race = (
         db.query(Race, Circuit)
@@ -578,12 +612,24 @@ def _get_circuit_info(season: int, rnd: int, db: Session) -> dict:
             "race_name": race_obj.slug.replace("-", " ").title() if race_obj.slug else None,
         }
 
-    # Fallback to calendar event if Race not found
+    # Fallback: use OpenF1 meeting data via calendar event meeting_key
     event = (
         db.query(CalendarEvent)
         .filter_by(season=season, round=rnd)
         .first()
     )
+    if event and event.meeting_key:
+        meeting = _fetch_openf1_meeting(event.meeting_key)
+        if meeting:
+            circuit_short = meeting.get("circuit_short_name") or ""
+            circuit_id = circuit_short.lower().replace(" ", "_").replace("-", "_") if circuit_short else f"circuit_{season}_{rnd}"
+            return {
+                "circuit_id": circuit_id,
+                "circuit_name": circuit_short or None,
+                "circuit_country": meeting.get("country_name") or None,
+                "race_name": meeting.get("meeting_name") or None,
+            }
+
     if event:
         return {
             "circuit_id": f"circuit_{season}_{rnd}",

--- a/src/theundercut/api/v1/race.py
+++ b/src/theundercut/api/v1/race.py
@@ -607,7 +607,7 @@ def _fetch_openf1_meeting(meeting_key: int) -> Optional[dict]:
                 meeting = data[0]
                 redis_client.setex(cache_key, OPENF1_MEETING_CACHE_TTL_SECONDS, json.dumps(meeting))
                 return meeting
-    except Exception as exc:
+    except (httpx.HTTPError, json.JSONDecodeError) as exc:
         logger.warning("Failed to fetch OpenF1 meeting %s: %s", meeting_key, exc)
     return None
 

--- a/web/src/components/race-weekend/RaceCountdown.tsx
+++ b/web/src/components/race-weekend/RaceCountdown.tsx
@@ -129,7 +129,7 @@ export function RaceCountdown({ targetDate, sessionType, label }: RaceCountdownP
         countdown.isImminent ? "animate-countdownPulse" : ""
       }`}
       role="timer"
-      aria-live="polite"
+      aria-live="off"
       aria-label={`${displayLabel}: ${countdown.days} days, ${countdown.hours} hours, ${countdown.minutes} minutes, ${countdown.seconds} seconds`}
     >
       <p className="text-[10px] sm:text-xs uppercase tracking-widest text-paper/50 mb-3 sm:mb-4">

--- a/web/src/components/race-weekend/RaceCountdown.tsx
+++ b/web/src/components/race-weekend/RaceCountdown.tsx
@@ -7,6 +7,7 @@ interface CountdownValues {
   days: number;
   hours: number;
   minutes: number;
+  seconds: number;
   isImminent: boolean;
   hasStarted: boolean;
 }
@@ -17,15 +18,16 @@ function formatCountdown(targetDate: string): CountdownValues {
   const diffMs = target.getTime() - now.getTime();
 
   if (diffMs <= 0) {
-    return { days: 0, hours: 0, minutes: 0, isImminent: true, hasStarted: true };
+    return { days: 0, hours: 0, minutes: 0, seconds: 0, isImminent: true, hasStarted: true };
   }
 
   const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
   const hours = Math.floor((diffMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
   const minutes = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((diffMs % (1000 * 60)) / 1000);
   const isImminent = diffMs < 24 * 60 * 60 * 1000; // Less than 24 hours
 
-  return { days, hours, minutes, isImminent, hasStarted: false };
+  return { days, hours, minutes, seconds, isImminent, hasStarted: false };
 }
 
 /**
@@ -37,10 +39,10 @@ function useCountdown(targetDate: string): CountdownValues | null {
   const [countdown, setCountdown] = useState<CountdownValues | null>(null);
 
   useEffect(() => {
-    setCountdown(formatCountdown(targetDate));
-    const interval = setInterval(() => {
-      setCountdown(formatCountdown(targetDate));
-    }, 60000); // Update every minute
+    // Compute initial value and start ticking every second
+    const tick = () => setCountdown(formatCountdown(targetDate));
+    tick();
+    const interval = setInterval(tick, 1000);
     return () => clearInterval(interval);
   }, [targetDate]);
 
@@ -96,6 +98,8 @@ export function RaceCountdown({ targetDate, sessionType, label }: RaceCountdownP
           <CountdownUnit value={0} label="hours" />
           <span className="text-2xl sm:text-3xl md:text-4xl text-paper/30 font-light">:</span>
           <CountdownUnit value={0} label="min" />
+          <span className="text-2xl sm:text-3xl md:text-4xl text-paper/30 font-light">:</span>
+          <CountdownUnit value={0} label="sec" />
         </div>
         <div className="mt-4 sm:mt-5 flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 text-paper/60">
           <span className="text-xs sm:text-sm" suppressHydrationWarning>{date}</span>
@@ -126,7 +130,7 @@ export function RaceCountdown({ targetDate, sessionType, label }: RaceCountdownP
       }`}
       role="timer"
       aria-live="polite"
-      aria-label={`${displayLabel}: ${countdown.days} days, ${countdown.hours} hours, ${countdown.minutes} minutes`}
+      aria-label={`${displayLabel}: ${countdown.days} days, ${countdown.hours} hours, ${countdown.minutes} minutes, ${countdown.seconds} seconds`}
     >
       <p className="text-[10px] sm:text-xs uppercase tracking-widest text-paper/50 mb-3 sm:mb-4">
         {displayLabel}
@@ -142,6 +146,8 @@ export function RaceCountdown({ targetDate, sessionType, label }: RaceCountdownP
         <CountdownUnit value={countdown.hours} label="hours" />
         <span className="text-2xl sm:text-3xl md:text-4xl text-paper/30 font-light">:</span>
         <CountdownUnit value={countdown.minutes} label="min" />
+        <span className="text-2xl sm:text-3xl md:text-4xl text-paper/30 font-light">:</span>
+        <CountdownUnit value={countdown.seconds} label="sec" />
       </div>
 
       <div className="mt-4 sm:mt-5 flex flex-col sm:flex-row items-center justify-center gap-1 sm:gap-2 text-paper/60">

--- a/web/src/components/race-weekend/__tests__/RaceCountdown.test.tsx
+++ b/web/src/components/race-weekend/__tests__/RaceCountdown.test.tsx
@@ -140,13 +140,13 @@ describe("RaceCountdown", () => {
   });
 
   describe("Accessibility", () => {
-    it("has role='timer' and aria-live='polite'", () => {
+    it("has role='timer' and aria-live='off'", () => {
       const targetDate = new Date("2026-03-17T14:00:00Z").toISOString();
 
       render(<RaceCountdown targetDate={targetDate} sessionType="race" />);
 
       const timer = screen.getByRole("timer");
-      expect(timer).toHaveAttribute("aria-live", "polite");
+      expect(timer).toHaveAttribute("aria-live", "off");
     });
 
     it("has descriptive aria-label", () => {


### PR DESCRIPTION
## Summary

Fixes two issues with the Upcoming Race widget on the homepage:

1. **Missing GP name/circuit info for upcoming races**: The `_get_circuit_info` backend function only looked up race metadata from the `core.races` table, which is only populated after a session is ingested. For upcoming (not-yet-ingested) rounds, it returned nulls. Now it falls back to the OpenF1 meetings API using the `meeting_key` stored on `CalendarEvent`, providing the GP name (e.g. "Japanese Grand Prix"), circuit name, and country. Results are cached in Redis for 1 hour.

2. **Countdown not ticking live**: The countdown timer was updating every 60 seconds and only displayed days/hours/minutes — users couldn't see it changing. Now it updates every second and displays a seconds unit.

3. **Circuit ID mapping for OpenF1 fallback**: Many OpenF1 `circuit_short_name` values (e.g. "Melbourne", "Sakhir", "Monte Carlo") don't match the Jolpica-style IDs the frontend expects (e.g. `albert_park`, `bahrain`, `monaco`). Added an explicit `OPENF1_TO_JOLPICA_CIRCUIT` mapping dict so the fallback produces correct `circuit_id` values, enabling circuit characteristics and the "learn more" link to resolve.

### Updates since last revision
- Narrowed exception catch in `_fetch_openf1_meeting` from bare `Exception` to `(httpx.HTTPError, json.JSONDecodeError)` per tembo[bot] review.
- Changed `aria-live` from `"polite"` to `"off"` on the countdown timer to avoid noisy per-second screen reader announcements. Updated test to match.

## Review & Testing Checklist for Human

- [ ] **Test on production after deploy**: Visit https://www.theundercut.co/ and confirm: (a) the upcoming race widget shows the GP name (e.g. "Japanese Grand Prix") with the country flag, (b) the countdown seconds tick visibly, and (c) the circuit characteristics section appears with score badges and a "Learn more" link.
- [ ] **Verify `circuit_name` display**: The OpenF1 fallback returns the short name (e.g. "Suzuka") rather than the full DB name ("Suzuka International Racing Course"). Characteristics lookup uses `circuit_id` so it should still work, but verify the displayed circuit name looks acceptable in the widget.
- [ ] **OpenF1 API latency on cold cache**: The fallback makes a synchronous HTTP call (10s timeout) on first request for a given meeting. Verify the first page load for an upcoming race doesn't feel sluggish. Subsequent requests are served from Redis cache.
- [ ] **Circuit mapping completeness**: The `OPENF1_TO_JOLPICA_CIRCUIT` mapping covers all 2024–2025 circuits where names diverge (verified all 24 programmatically). Future new venues would need a mapping entry if OpenF1's `circuit_short_name` doesn't naively normalize to the Jolpica ID.

**Suggested test plan**: After deploying, hard-refresh `https://www.theundercut.co/`. Confirm the widget title shows the GP name, the countdown seconds tick down visibly each second, and the "Circuit Characteristics" section appears with score badges. Open DevTools Console and verify no React error #418.

### Notes
- `httpx` was already a project dependency (used in `calendar_loader.py`), so no new packages were added.
- No backend tests were added for `_fetch_openf1_meeting` — it's a thin caching wrapper around the OpenF1 API.
- The 91 existing frontend tests all pass.
- `aria-live="off"` means screen readers won't auto-announce timer changes; the `aria-label` is still present for on-demand reading.

Link to Devin session: https://app.devin.ai/sessions/05a81a5807984651a9ea1e8d021e7844
Requested by: @alamine42