### PR TITLE
fix: replace unicode escape sequences with actual emoji characters in HistoricalData

### DIFF
--- a/web/src/components/race-weekend/HistoricalData.tsx
+++ b/web/src/components/race-weekend/HistoricalData.tsx
@@ -2,7 +2,7 @@ import { TeamWithLogo } from "@/components/ui/team-logo";
 import type { HistoricalDataProps } from "./types";
 
 const POSITION_MEDALS = ["1st", "2nd", "3rd"];
-const POSITION_EMOJIS = ["\u{1F947}", "\u{1F948}", "\u{1F949}"]; // Gold, Silver, Bronze medals
+const POSITION_EMOJIS = ["🥇", "🥈", "🥉"]; // Gold, Silver, Bronze medals
 
 interface PodiumItemProps {
   position: number;
@@ -96,14 +96,14 @@ export function HistoricalData({ history }: HistoricalDataProps) {
         <div className="grid grid-cols-2 gap-2 content-start">
           {previous_year.pole && (
             <StatItem
-              icon="\u{2B50}"
+              icon="⭐"
               label="Pole Position"
               value={previous_year.pole.driver_code}
             />
           )}
           {previous_year.fastest_lap && (
             <StatItem
-              icon="\u{26A1}"
+              icon="⚡"
               label="Fastest Lap"
               value={`${previous_year.fastest_lap.driver_code}${
                 previous_year.fastest_lap.time ? ` ${previous_year.fastest_lap.time}` : ""


### PR DESCRIPTION
## Summary

Replaces Unicode escape sequences (`\u{2B50}`, `\u{26A1}`, `\u{1F947}`, etc.) with literal emoji characters in `HistoricalData.tsx`. Users were seeing raw escape text like `\u{2B50}` in the Pole Position and Fastest Lap stat cards instead of the intended ⭐ and ⚡ emojis.

While `\u{...}` is valid ES6 syntax, it was being rendered as literal text in production (likely due to build-time string escaping). Using the actual emoji characters directly is the most reliable approach.

The podium medal emojis (🥇🥈🥉) were also updated preventatively, even though the user only reported the issue on the stat cards.

## Review & Testing Checklist for Human

- [ ] After deploying, verify on https://www.theundercut.co/ that the Pole Position card shows ⭐ and the Fastest Lap card shows ⚡ (not `\u{2B50}` / `\u{26A1}`)
- [ ] Verify the podium medals (🥇🥈🥉) still render correctly in the "Last Year" section

### Notes
- All 91 existing frontend tests pass.
- Only one file changed (`HistoricalData.tsx`), no logic changes — purely string literal replacements.

Link to Devin session: https://app.devin.ai/sessions/05a81a5807984651a9ea1e8d021e7844
Requested by: @alamine42